### PR TITLE
UX: custom banner styling for mint theme

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -85,10 +85,13 @@ input[type="color"]:focus,
   }
 }
 
-.wrap.custom-search-banner-wrap {
+.navigation-categories .search-banner {
   @include border-radius;
   height: 350px;
-  padding: 6.5em 0 3em;
+  box-sizing: border-box;
+  padding: 2.5em 0 3em;
+  margin: 1em auto;
+  max-width: 1110px;
 }
 
 .category-box-inner {


### PR DESCRIPTION
Fixes the issue mentioned here: https://meta.discourse.org/t/mint-a-modern-theme-for-discourse/202822/15?u=meghna

This change was required because of the change upstream: https://github.com/discourse/discourse-search-banner/commit/703d7c4dd60c97da7b73e36a1b3e70390c2877c8