### PR TITLE
UX: fix border for header search

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -119,6 +119,10 @@ input[type="color"]:focus,
   color: $color-white;
 }
 
+.search-menu .search-input {
+  border: 0;
+}
+
 .menu-panel .d-label {
   color: $color-black;
 }


### PR DESCRIPTION
Before:

<img width="624" alt="Screenshot 2022-06-15 at 20 27 35" src="https://user-images.githubusercontent.com/11170663/173859448-53527f1e-02b7-4460-9b50-682b22dcb007.png">

After:

<img width="622" alt="Screenshot 2022-06-15 at 20 28 12" src="https://user-images.githubusercontent.com/11170663/173859461-3b6e1683-8cc1-486a-ab86-306544560b0b.png">
