### PR TITLE
UX: Add dark mode support

### DIFF
--- a/about.json
+++ b/about.json
@@ -3,13 +3,23 @@
   "about_url": "https://meta.discourse.org/t/mint-a-modern-theme-for-discourse/202822",
   "license_url": "https://github.com/discourse/discourse-mint-theme/blob/main/LICENSE",
   "color_schemes": {
-    "mint": {
+    "mint-light": {
       "primary": "454545",
       "secondary": "F6FBFC",
       "tertiary": "4F8A7C",
       "header_background": "ffffff",
       "header_primary": "111111"
+    },
+    "mint-dark": {
+      "primary": "e0e0e0",
+      "secondary": "2d2d2d",
+      "tertiary": "4F8A7C",
+      "header_background": "202020",
+      "header_primary": "e0e0e0"
     }
   },
-  "components": ["https://github.com/discourse/discourse-showcased-categories.git","https://github.com/discourse/discourse-search-banner.git"]
+  "components": [
+    "https://github.com/discourse/discourse-showcased-categories.git",
+    "https://github.com/discourse/discourse-search-banner.git"
+  ]
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -57,7 +57,7 @@ input[type="color"]:focus,
   .col {
     position: relative;
     @include border-radius;
-    background: $color-white;
+    @include mint-card-bg;
     padding: 2em 2em 1em;
     border-top: 8px solid $tertiary;
     box-shadow: 0 8px 60px 0 rgba(103, 151, 255, 0.1),
@@ -79,7 +79,7 @@ input[type="color"]:focus,
       &:hover {
         background: var(--tertiary);
         color: var(--secondary);
-        box-shadow: 4px 4px $color-box-shadow;
+        box-shadow: 4px 4px var(--mint-hover-shadow);
         transition: 0.3s;
         @include border-radius;
       }
@@ -97,7 +97,7 @@ input[type="color"]:focus,
 }
 
 .category-box-inner {
-  background: $color-white;
+  @include mint-card-bg;
 }
 
 .navigation-topics {
@@ -106,7 +106,7 @@ input[type="color"]:focus,
     box-shadow: 0 8px 60px 0 rgba(103, 151, 255, 0.1),
       0 12px 90px 0 rgba(133, 255, 103, 0.1);
     padding: 2em;
-    background-color: $color-white;
+    @include mint-card-bg;
     border-top: 8px solid $tertiary;
     margin-top: 0.8em;
   }
@@ -119,7 +119,7 @@ input[type="color"]:focus,
 }
 
 .search-menu .search-context .show-help {
-  color: $color-white;
+  color: var(--primary-very-low);
 }
 
 .search-menu .search-input {
@@ -127,7 +127,7 @@ input[type="color"]:focus,
 }
 
 .menu-panel .d-label {
-  color: $color-black;
+  color: var(--primary);
 }
 
 a {
@@ -173,7 +173,7 @@ a {
   border-right: 1px solid var(--primary-low) !important;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.1);
   margin: 0 0.59em 2em 0.59em;
-  background: white;
+  background: var(--primary-very-low);
 }
 
 #create-topic {
@@ -189,7 +189,7 @@ a {
   &:hover {
     background: var(--tertiary);
     color: var(--secondary);
-    box-shadow: 4px 4px $color-box-shadow;
+    box-shadow: var(--mint-hover-shadow);
     transition: all 0.3s linear;
     @include border-radius;
     .fa {
@@ -217,7 +217,7 @@ a {
 .list-controls .combo-box .combo-box-header {
   border: none;
   @include border-radius;
-  background-color: $color-white;
+  @include mint-card-bg;
 }
 
 .menu-panel .panel-body-bottom .btn {
@@ -243,9 +243,9 @@ a {
   &.active {
     @include border-radius;
     transition: all 0.3s linear;
-    background: $color-mint;
+    background: var(--mint-color-mint);
     color: var(--secondary);
-    border: 1px solid $color-mint;
+    border: 1px solid var(--mint-color-mint);
   }
 }
 
@@ -366,7 +366,7 @@ a:hover {
 
 .custom-search-banner-wrap h1,
 .custom-search-banner-wrap p {
-  color: $color-white;
+  color: var(--primary-very-low);
 }
 
 .btn[href] {

--- a/common/common.scss
+++ b/common/common.scss
@@ -16,7 +16,7 @@ input[type="tel"],
 input[type="color"],
 .d-editor-textarea-wrapper,
 .select-kit-header {
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
 }
 
 input[type="text"]:focus,
@@ -38,7 +38,7 @@ input[type="color"]:focus,
 .select-kit.single-select.is-expanded .select-kit-header:not(.btn),
 .select-kit.single-select .select-kit-header:not(.btn):focus,
 .select-kit.single-select .select-kit-header:not(.btn):active {
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   box-shadow: none;
   outline: none;
 }
@@ -56,7 +56,7 @@ input[type="color"]:focus,
   margin: 2em 0 2em 0;
   .col {
     position: relative;
-    @include border-radius;
+    border-radius: var(--mint-border-radius);
     @include mint-card-bg;
     padding: 2em 2em 1em;
     border-top: 8px solid $tertiary;
@@ -73,7 +73,7 @@ input[type="color"]:focus,
       color: var(--secondary);
       background: var(--tertiary);
       transition: all 0.3s linear;
-      @include border-radius;
+      border-radius: var(--mint-border-radius);
       text-transform: uppercase;
       border: 1px solid var(--tertiary);
       &:hover {
@@ -81,14 +81,14 @@ input[type="color"]:focus,
         color: var(--secondary);
         box-shadow: 4px 4px var(--mint-hover-shadow);
         transition: 0.3s;
-        @include border-radius;
+        border-radius: var(--mint-border-radius);
       }
     }
   }
 }
 
 .navigation-categories .search-banner {
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   height: 350px;
   box-sizing: border-box;
   padding: 2.5em 0 3em;
@@ -102,7 +102,7 @@ input[type="color"]:focus,
 
 .navigation-topics {
   .container.list-container {
-    @include border-radius;
+    border-radius: var(--mint-border-radius);
     box-shadow: 0 8px 60px 0 rgba(103, 151, 255, 0.1),
       0 12px 90px 0 rgba(133, 255, 103, 0.1);
     padding: 2em;
@@ -115,7 +115,7 @@ input[type="color"]:focus,
 .search-widget .search-context {
   padding: 10px;
   background-color: var(--tertiary-medium);
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
 }
 
 .search-menu .search-context .show-help {
@@ -138,7 +138,7 @@ a {
   display: grid;
   grid-gap: 2em;
   grid-template-columns: 32% 32% 32%;
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   .category-box {
     width: 100%;
     margin: 0;
@@ -146,7 +146,7 @@ a {
     border: none;
     border-top: 8px solid;
     background: var(--secondary);
-    @include border-radius;
+    border-radius: var(--mint-border-radius);
     box-shadow: 0px 2px 3px 0px rgba(2, 47, 57, 0.14);
     .category-box-inner {
       border: none;
@@ -169,7 +169,7 @@ a {
 }
 
 .category-list-item.category {
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   border-right: 1px solid var(--primary-low) !important;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.1);
   margin: 0 0.59em 2em 0.59em;
@@ -180,7 +180,7 @@ a {
   color: var(--secondary);
   background: var(--tertiary);
   transition: all 0.3s linear;
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   text-transform: uppercase;
   border: 2px solid var(--tertiary);
   .fa {
@@ -191,7 +191,7 @@ a {
     color: var(--secondary);
     box-shadow: var(--mint-hover-shadow);
     transition: all 0.3s linear;
-    @include border-radius;
+    border-radius: var(--mint-border-radius);
     .fa {
       color: var(--secondary);
     }
@@ -216,7 +216,7 @@ a {
 
 .list-controls .combo-box .combo-box-header {
   border: none;
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   @include mint-card-bg;
 }
 
@@ -232,16 +232,16 @@ a {
 
 .nav-pills li a {
   border: 1px solid transparent;
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   &:hover {
-    @include border-radius;
+    border-radius: var(--mint-border-radius);
     transition: all 0.3s linear;
     background-color: transparent;
     color: var(--tertiary);
     border: 1px dashed var(--tertiary);
   }
   &.active {
-    @include border-radius;
+    border-radius: var(--mint-border-radius);
     transition: all 0.3s linear;
     background: var(--mint-color-mint);
     color: var(--secondary);
@@ -251,7 +251,7 @@ a {
 
 .select-kit.dropdown-select-box .dropdown-select-box-header {
   background: var(--tertiary);
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   border: 1px solid var(--tertiary);
   color: var(--secondary);
   svg {
@@ -306,7 +306,7 @@ a {
   color: var(--secondary);
   background: var(--tertiary);
   transition: all 0.3s linear;
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   text-transform: uppercase;
   border: 1px solid var(--tertiary);
   .fa {
@@ -315,7 +315,7 @@ a {
 }
 
 .btn-primary {
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
 }
 
 .discourse-no-touch .btn-danger:hover {
@@ -323,7 +323,7 @@ a {
 }
 
 .create {
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
 }
 
 .select-kit .select-kit-row.is-selected {
@@ -333,7 +333,7 @@ a {
 .modal-inner-container,
 .edit-category-footer {
   .btn-primary {
-    @include border-radius;
+    border-radius: var(--mint-border-radius);
   }
 }
 
@@ -360,7 +360,7 @@ a:hover {
     color: var(--secondary);
   }
   .btn-primary {
-    @include border-radius;
+    border-radius: var(--mint-border-radius);
   }
 }
 

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,7 +1,7 @@
 @import "variables";
 
 body:not(.navigation-categories):not(.navigation-topics) #main-outlet {
-  @include border-radius;
+  border-radius: var(--mint-border-radius);
   box-shadow: 0 8px 60px 0 rgba(103, 151, 255, 0.1),
     0 12px 90px 0 rgba(133, 255, 103, 0.1);
   padding: 2em;

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -5,9 +5,15 @@ body:not(.navigation-categories):not(.navigation-topics) #main-outlet {
   box-shadow: 0 8px 60px 0 rgba(103, 151, 255, 0.1),
     0 12px 90px 0 rgba(133, 255, 103, 0.1);
   padding: 2em;
-  background-color: $color-white;
+  @include mint-card-bg;
   border-top: 8px solid $tertiary;
   margin-top: 0.8em;
+}
+
+.boxed {
+  &.white {
+    @include mint-card-bg;
+  }
 }
 
 #main-outlet:after {
@@ -18,7 +24,7 @@ body:not(.navigation-categories):not(.navigation-topics) #main-outlet {
   width: 500px;
   height: 500px;
   border-radius: 2000px;
-  background: $color-blue;
+  background: var(--mint-color-blue);
   right: 1px;
   top: -57px;
 }

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -2,14 +2,28 @@
   border-radius: 10px;
 }
 
-$color-white: #ffffff;
-$color-black: #000000;
-$color-box-shadow: #65a797;
-$color-mint: #75bdad;
-$color-blue: #e5f8ff;
+@mixin mint-card-bg {
+  background: var(--primary-very-low);
+
+  @media (prefers-color-scheme: light) {
+    background: var(--header_background);
+  }
+}
+
+:root {
+  --mint-hover-shadow: 4px 4px var(--tertiary-high);
+  --mint-color-mint: #75bdad;
+  --mint-color-blue: #e5f8ff;
+  --mint-color-square-gradient: linear-gradient(
+    4deg,
+    ter rgba(143, 236, 202, 0.29) 55%,
+    rgba(74, 247, 255, 0.08) 100%
+  );
+}
+
 $color-square-gradient: linear-gradient(
   4deg,
-  rgba(143, 236, 202, 0.29) 55%,
+  ter rgba(143, 236, 202, 0.29) 55%,
   rgba(74, 247, 255, 0.08) 100%
 );
 $color-square-webkit-gradient: -webkit-linear-gradient(

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,7 +1,3 @@
-@mixin border-radius {
-  border-radius: 10px;
-}
-
 @mixin mint-card-bg {
   background: var(--primary-very-low);
 
@@ -11,6 +7,7 @@
 }
 
 :root {
+  --mint-border-radius: 10px;
   --mint-hover-shadow: 4px 4px var(--tertiary-high);
   --mint-color-mint: #75bdad;
   --mint-color-blue: #e5f8ff;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -20,7 +20,7 @@
 
 $color-square-gradient: linear-gradient(
   4deg,
-  ter rgba(143, 236, 202, 0.29) 55%,
+  rgba(143, 236, 202, 0.29) 55%,
   rgba(74, 247, 255, 0.08) 100%
 );
 $color-square-webkit-gradient: -webkit-linear-gradient(


### PR DESCRIPTION
This PR adds support for dark mode with this theme enabled by:
- Having two separate color schemes: `mint-light` and `mint-dark`
- Converting SCSS variables to CSS custom properties