### PR TITLE
UX: Support new sidebar

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,4 +1,5 @@
 @import 'variables';
+@import 'sidebar';
 
 input[type="text"],
 input[type="password"],

--- a/javascripts/discourse/api-initializers/discourse-mint-theme.js
+++ b/javascripts/discourse/api-initializers/discourse-mint-theme.js
@@ -1,0 +1,34 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("0.11.1", (api) => {
+  api.onPageChange(() => {
+    const mintHeaderItems = document.querySelector(".mint-header-elements");
+    if (mintHeaderItems) {
+      return;
+    } else {
+      // This is done to ensure ordering of search banner followed by showcased topic list
+
+      // Find relevant elements
+      const showcasedTopicList = document.querySelector(
+        ".above-main-container-outlet.showcased-topic-list"
+      );
+      const searchBanner = document.querySelector(
+        ".above-main-container-outlet.search-banner"
+      );
+      const mainContainer = document.querySelector("#main-container");
+
+      // Add necessary classes
+      showcasedTopicList.classList.add("mint-showcased-topic-list");
+      searchBanner.classList.add("mint-search-banner");
+
+      // Create wrapper div and append elements
+      const wrapper = document.createElement("div");
+      wrapper.classList.add("mint-header-elements");
+      wrapper.appendChild(searchBanner);
+      wrapper.appendChild(showcasedTopicList);
+
+      // Add new wrapper with re-ordered elements to main container
+      mainContainer.before(wrapper, mainContainer);
+    }
+  });
+});

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,0 +1,8 @@
+#main-outlet-wrapper {
+  .sidebar-wrapper {
+      --d-sidebar-highlight-color: var(--tertiary-low);
+
+    background-color: var(--secondary);
+    box-shadow: 0 8px 60px 0 rgba(103,151,255,.10), 0 12px 90px 0 rgba(133,255,103,.10);
+  }
+}


### PR DESCRIPTION
This PR adds support for the sidebar by:
1. Adding `mint-theme` specific styling for the sidebar
2. Fitting add-on theme components in view with sidebar
   - This is done by:
      - > To support the sidebar, both add-on theme components (`search-banner` and `showcased-topic-list`) need to use the `above-main-container` plugin outlet. However, this JS logic ensures that the search banner always appears first in the ordering of the outlet items.