### PR TITLE
FIX: use core sidebar hover color

### DIFF
--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,7 +1,5 @@
 #main-outlet-wrapper {
   .sidebar-wrapper {
-    --d-sidebar-highlight-color: var(--tertiary-low);
-
     background-color: var(--secondary);
     box-shadow: 0 8px 60px 0 rgba(103, 151, 255, 0.1),
       0 12px 90px 0 rgba(133, 255, 103, 0.1);


### PR DESCRIPTION
**Before**
<img width="277" alt="image" src="https://github.com/discourse/discourse-mint-theme/assets/30537603/0f264485-158b-4176-9abc-4c893cb6a47c">

**After**
<img width="267" alt="image" src="https://github.com/discourse/discourse-mint-theme/assets/30537603/4d057263-73bf-46d8-af0c-ee1ff3d8878b">
