### PR TITLE
UX: fix double component appearance, nav

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,11 +9,16 @@
 
 :root {
   --d-input-border-radius: var(--mint-border-radius);
+  --d-nav-underline-height: 0;
 }
 
 .d-header {
   height: 5em;
   box-shadow: none;
+}
+
+.d-header-mode .bootstrap-mode {
+  color: var(--secondary);
 }
 
 .alert.alert-info {
@@ -373,13 +378,16 @@ summary.select-kit-header.single-select-header.dropdown-select-box-header {
   display: none;
 }
 
-.showcased-topic-list {
+.custom-homepage-columns {
   display: none;
 }
 
 .mint-component-extensions {
-  .search-banner,
-  .showcased-topic-list {
+  .search-banner {
     display: block;
+  }
+
+  .custom-homepage-columns {
+    display: flex;
   }
 }


### PR DESCRIPTION
This fixes a class change that caused the showcased categories to appear twice, and also a fix for a core nav change. 

before:

![image](https://github.com/discourse/discourse-mint-theme/assets/1681963/3631f3a5-a89e-4bab-80cf-18ad5ebe9682)

![image](https://github.com/discourse/discourse-mint-theme/assets/1681963/8749fe5f-f00e-4429-9d89-0ae9e4cee888)


after:

![image](https://github.com/discourse/discourse-mint-theme/assets/1681963/f5bce364-3668-4fb3-aa2a-5a752d8cb43e)

![image](https://github.com/discourse/discourse-mint-theme/assets/1681963/33d1b1ed-2034-452c-9f76-e5dcd2247b86)

