### PR TITLE
UX: fix layout for categories grid

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -112,9 +112,7 @@ a {
 }
 
 .category-boxes {
-  display: grid;
   grid-gap: 2em;
-  grid-template-columns: 32% 32% 32%;
   border-radius: var(--mint-border-radius);
   .category-box {
     width: 100%;


### PR DESCRIPTION
This layout uses grid in core now, so the grid definition here can conflict a little and cause layout issues... 

before (overflows on right):
![image](https://github.com/discourse/discourse-mint-theme/assets/1681963/29510ade-499a-4ded-ba30-fab9487f20e2)

after: 
![image](https://github.com/discourse/discourse-mint-theme/assets/1681963/e910d174-7185-4b9f-92b3-e61b3badabdf)

and with the category groups component added:

before:
![image](https://github.com/discourse/discourse-mint-theme/assets/1681963/1f0d31f8-1050-434e-8af7-4086293d11a6)


after:
![image](https://github.com/discourse/discourse-mint-theme/assets/1681963/4b1d31ad-67ad-4429-8ea9-cd59d7b66e46)
