### PR TITLE
UX: fix fullscreen chat scroll

### DIFF
--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -1,6 +1,6 @@
 html body.has-sidebar-page.has-full-page-chat {
   #main-outlet-wrapper {
-    gap: 2em;
+    gap: 0 2em;
   }
 
   #main-outlet {
@@ -18,7 +18,7 @@ html body.has-sidebar-page.has-full-page-chat {
 
 .desktop-view .has-full-page-chat {
   .chat-channel {
-    height: calc(100vh - (var(--header-offset) + 3em));
+    height: calc(100vh - (var(--header-offset) + 6em));
   }
 }
 


### PR DESCRIPTION
Without this fix:

![grafik](https://github.com/user-attachments/assets/f542beca-75d8-4e62-bcd7-46faeb73dff4)

There are 2 scrollbars, one for the chat content and one for the entire page.

With this fix:

![grafik](https://github.com/user-attachments/assets/4a43a565-edda-435e-890a-11eb3d5023fb)

There is only a scrollbar for the chat content.

Tested on Discourse 3.4.3